### PR TITLE
Add Repeated Motions with the Number Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently supported features:
 * Normal mode
     * Getting to insert mode with the "i" key
     * Moving with the home-row keys
+    * Repeated motions using the number keys
 * Chrome (tested on 63.0)
 * (Not really) Firefox
     * It will install, but many of the features work incorrectly.

--- a/docs-vim.js
+++ b/docs-vim.js
@@ -1,3 +1,4 @@
+num = '';
 vim = {
     "mode": "insert",
     "keys": {
@@ -37,12 +38,23 @@ vim.normal_keydown = function (e) {
     keyMap[vim.keys.move[2]] = "ArrowUp";
     keyMap[vim.keys.move[3]] = "ArrowRight";
 
+    if (e.key.match(/\d+/)) {
+        num += e.key.toString();
+    }
+
     if (e.key in keyMap) {
         e.key = keyMap[e.key];
     }
 
     if (e.key.indexOf("Arrow") == 0 || e.key == "Delete") {
-        docs.pressKey(docs.codeFromKey(e.key));
+	if (num != '') {
+	    for (var i = 0; i < Number(num); i++) {
+                docs.pressKey(docs.codeFromKey(e.key));
+            }
+	    num = '';
+        } else {
+	    docs.pressKey(docs.codeFromKey(e.key));
+	}
     }
 
     if (e.key == "V" && e.shift) {

--- a/docs-vim.js
+++ b/docs-vim.js
@@ -1,6 +1,6 @@
-num = '';
 vim = {
     "mode": "insert",
+    "num": "",
     "keys": {
         "move": "dhtn", // QWERTY: hjkl
         "escapeSequence": "hn", // QWERTY: jk or jl
@@ -9,6 +9,7 @@ vim = {
 
 vim.switchToNormalMode = function () {
     vim.mode = "normal";
+    vim.num = "";
     docs.setCursorWidth("7px");
 };
 
@@ -47,14 +48,13 @@ vim.normal_keydown = function (e) {
     }
 
     if (e.key.indexOf("Arrow") == 0 || e.key == "Delete") {
-	if (num != '') {
-	    for (var i = 0; i < Number(num); i++) {
-                docs.pressKey(docs.codeFromKey(e.key));
-            }
-	    num = '';
-        } else {
-	    docs.pressKey(docs.codeFromKey(e.key));
+	if (vim.num.length == 0 || isNaN(vim.num)) {
+            vim.num = "1";
 	}
+	for (var i = 0; i < Number(vim.num); i++) {
+            docs.pressKey(docs.codeFromKey(e.key));
+	}
+	vim.num = "";
     }
 
     if (e.key == "V" && e.shift) {


### PR DESCRIPTION
Adds the ability to repeat motions by typing a number before typing the motion. e.g. type ```4j``` in normal mode to move the cursor down 4 lines.